### PR TITLE
Add RO Planner module to panels

### DIFF
--- a/GameData/ROSolar/Parts/ROS-FoldingSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-FoldingSolarPanel.cfg
@@ -104,8 +104,4 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
-	MODULE:NEEDS[RealismOverhaul]
-	{
-		name = ModuleROSolarPanel
-	}
 }

--- a/GameData/ROSolar/Parts/ROS-FoldingSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-FoldingSolarPanel.cfg
@@ -104,4 +104,8 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
+	MODULE:NEEDS[RealismOverhaul]
+	{
+		name = ModuleROSolarPanel
+	}
 }

--- a/GameData/ROSolar/Parts/ROS-HingedSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-HingedSolarPanel.cfg
@@ -103,4 +103,8 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
+	MODULE:NEEDS[RealismOverhaul]
+	{
+		name = ModuleROSolarPanel
+	}
 }

--- a/GameData/ROSolar/Parts/ROS-HingedSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-HingedSolarPanel.cfg
@@ -103,8 +103,4 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
-	MODULE:NEEDS[RealismOverhaul]
-	{
-		name = ModuleROSolarPanel
-	}
 }

--- a/GameData/ROSolar/Parts/ROS-StaticSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-StaticSolarPanel.cfg
@@ -107,4 +107,8 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
+	MODULE:NEEDS[RealismOverhaul]
+	{
+		name = ModuleROSolarPanel
+	}
 }

--- a/GameData/ROSolar/Parts/ROS-StaticSolarPanel.cfg
+++ b/GameData/ROSolar/Parts/ROS-StaticSolarPanel.cfg
@@ -107,8 +107,4 @@ PART
 		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
 		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
 	}
-	MODULE:NEEDS[RealismOverhaul]
-	{
-		name = ModuleROSolarPanel
-	}
 }


### PR DESCRIPTION
**NOTE** Please Squash when this is merged!

This adds the RO planner module to the panels so you can see wattage at various bodies and calculate degradation.

**Caveat**: The planner doesn't update as you change dynamic properties, so you have to re-open the PAW to see the updates.  To fix this would involve code and is something I may look at, but for now, this is better than nothing.