### PR TITLE
Added NearFutureSolar support

### DIFF
--- a/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_BlanketSolarPanel.cfg
+++ b/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_BlanketSolarPanel.cfg
@@ -1,0 +1,54 @@
+// Blanket solar arrays, which should be unlocked later on for realism reasons
++PART[ROS-StaticSolarPanel]:NEEDS[NearFutureSolar]
+{
+	@name = ROS-BlanketSolarPanel
+    @title = Blanket Solar Panel
+    @description = This blanket solar panel allows you to choose different shapes, resize the panel and select the level of solar panel.
+    @tags = proc, procedural, solar, power, blanket
+
+	!MODULE[ModuleROSolar],* {}
+    MODULE
+    {
+        name = ModuleROSolar
+        currentVariant = Circular
+        currentCore = NFS_DeployingBlk_orion-1
+        solarPanelType = folded
+        coreNodeNames = none
+
+		CORE
+		{
+			variant = Circular
+			model = NFS_DeployingBlk_orion-1
+			model = NFS_DeployingBlk_arm-1				
+		}
+		
+		CORE
+		{
+			variant = Rectangular
+			model = NFS_DeployingBlk_copernicus-1
+			model = NFS_DeployingBlk_dsg-1
+			model = NFS_DeployingBlk_nautilus-1
+		}
+		
+		CORE
+		{
+			variant = Fan
+			model = NFS_DeployingBlk_starship-1
+			model = NFS_DeployingBlk_bfs-1	
+		}
+		
+		CORE
+		{
+			variant = Array
+			model = NFS_DeployingBlk_drm-1
+			model = NFS_DeployingBlk_dst-1	
+		}
+		
+		isBreakable = true
+		resourceName = ElectricCharge
+		chargeRate = 0.081
+		extendActionName = #autoLOC_6001805 //#autoLOC_6001805 = Extend <<1>>
+		retractActionName = #autoLOC_6001806 //#autoLOC_6001806 = Retract <<1>>
+		extendpanelsActionName = #autoLOC_6001807 //#autoLOC_6001807 = Toggle <<1>>	
+	}
+}

--- a/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_PanelModels.cfg
+++ b/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_PanelModels.cfg
@@ -1,0 +1,548 @@
+// ===================== DEPLOYABLE =====================
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_ikonos-1
+	title = Ikonos
+	description = The IKONOS solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x1-ikonos-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.006
+	panelLength = 0.343
+	panelWidth = 1.306
+	panelArea = 0.0416
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_Ikonos_Base
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_messenger-1
+	title = MESSENGER
+	description = The MESSENGER solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x1-messenger-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.006
+	panelLength = 1.37
+	panelWidth = 1.37
+	panelArea = 1.0816
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_Messenger_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_mro-1
+	title = MRO
+	description = The MRO solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x2-mro-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.008
+	panelLength = 1.403
+	panelWidth = 0.625
+	panelArea = 0.7344
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsMRO_Pivot
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_wv4-1
+	title = WorldView4
+	description = The WorldView-4 solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x2-wv4-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.008
+	panelLength = 2
+	panelWidth = 0.750
+	panelArea = 0.896
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_WV4_PanelBase
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_orion-1
+	title = Orion
+	description = The Orion ESM solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x3-orion-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.01
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.292
+	panelLength = 2.823
+	panelWidth = 0.625
+	panelArea = 1.0464
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsOrionPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_orion-2
+	title = Orion [Retractable]
+	description = Retractable version of the Orion ESM solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x3-orion-2
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 2.823
+	panelWidth = 0.625
+	panelArea = 1.0464
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsOrionPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_dragon-1
+	title = Dragon
+	description = The Dragon solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x4-dragon-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 2.625
+	panelWidth = 1
+	panelArea = 1.1136
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelDragonPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_dragon-2
+	title = Dragon [Retractable]
+	description = The retractable version of the Dragon solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x4-dragon-2
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 2.625
+	panelWidth = 1
+	panelArea = 1.1136
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelDragonPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_dawn-1
+	title = Dawn
+	description = The Dawn solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x5-dawn-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.292
+	panelLength = 3.826
+	panelWidth = 1.443
+	panelArea = 3.504
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsDawnPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_goes-1
+	title = GOES
+	description = The GOES solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-1x5-goes-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.025
+	panelLength = 4.185
+	panelWidth = 1.7
+	panelArea = 4.48
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsGOESPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_lab-1
+	title = Lab
+	description = The LAB solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-2x6x6-lab-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.04
+	panelLength = 5.7
+	panelWidth = 3.465
+	panelArea = 8.7168
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsLabPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_hub-1
+	title = Hub
+	description = The HUB solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-2x20-hub-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 9.422
+	panelWidth = 3.31
+	panelArea = 16.608
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsHub_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_hayabusa-1
+	title = Hayabusa
+	description = The Hayabusa solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-3x1-hayabusa-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.006
+	panelLength = 4.175
+	panelWidth = 0.930
+	panelArea = 2.416
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_HayabusaBase
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_tdrss-1
+	title = TDRSS
+	description = The TDRSS solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-3x1-tdrss-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.006
+	panelLength = 1.2
+	panelWidth = 1
+	panelArea = 0.7552
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsTDRSSPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingAdv_wv3-1
+	title = WorldView3
+	description = The WorldView-3 solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-advanced/nfs-panel-deploying-advanced-3x1-wv3-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.001
+	panelLength = 1.25
+	panelWidth = 1.125
+	panelArea = 0.9392
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_WV3_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+// ===================== BLANKET =====================
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_arm-1
+	title = ARM
+	description = The ARM solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-arm-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.008
+	panelLength = 14
+	panelWidth = 14
+	panelArea = 86.048
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_ARM_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_bfs-1
+	title = BFS
+	description = The BFS solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-bfs-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.001
+	panelLength = 15
+	panelWidth = 8.75
+	panelArea = 44.928
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_BFS_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_copernicus-1
+	title = Copernicus
+	description = The Copernicus MTV solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-copernicus-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.001
+	panelLength = 3.75
+	panelWidth = 3.75
+	panelArea = 5.568
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsSolo_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_drm-1
+	title = DRM
+	description = The DRM solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-drm-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 30
+	panelWidth = 19
+	panelArea = 292.864
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_DRM_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_dsg-1
+	title = Gateway
+	description = The Deep Space Gateway solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-dsg-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.015
+	panelLength = 21.25
+	panelWidth = 7.90
+	panelArea = 56.32
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_GatewayPanelPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_dst-1
+	title = DST
+	description = The Deep Space Transport solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-dst-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 26.5
+	panelWidth = 9.5
+	panelArea = 135.168
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_DSTPanelPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_nautilus-1
+	title = Nautilus
+	description = The Nautilus solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-nautilus-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 10.875
+	panelWidth = 3.75
+	panelArea = 16.704
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsTrio_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_orion-1
+	title = Orion
+	description = The Orion (Constellation Program) solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-orion-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.005
+	panelLength = 1.278
+	panelWidth = 1.278
+	panelArea = 0.64
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_UltraFlex_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingBlk_starship-1
+	title = Starship
+	description = The Starship solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-blanket/nfs-panel-deploying-blanket-starship-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 3
+	panelWidth = 7
+	panelArea = 11.02
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_Star_ArmsPivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+// CONCENTRATING
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingCon_juice-1
+	title = JUICE
+	description = The JUICE solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-concentrator/nfs-panel-deploying-concentrator-1x3x1-juice-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.015
+	panelLength = 3.25
+	panelWidth = 2
+	panelArea = 1.8464
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsJuice_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+
+ROL_MODEL:NEEDS[NearFutureSolar]
+{
+	name = NFS_DeployingCon_juno-1
+	title = JUNO
+	description = The Juno solar panel. Credit: NearFutureSolar by Nertea
+	modelName = NearFutureSolar/Parts/SolarPanels/deploying-concentrator/nfs-panel-deploying-concentrator-1x4-juno-1
+	rotationOffset = 0, 0, 0
+	diameter = 0.233
+	minVerticalScale = 0.0001
+	maxVerticalScale = 999
+	height = 0.01
+	panelLength = 2.875
+	panelWidth = 0.8
+	panelArea = 1.1936
+	secondaryTransformName = Suncatcher
+	animationName = PanelsExtend
+	pivotName = B_PanelsJuno_Pivot
+	surface = 0,0,0,1,0,0,1
+	isTracking = false
+}

--- a/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_PartRemover.cfg
+++ b/GameData/ROSolar/ModIntegration/NearFutureSolar/NFS_PartRemover.cfg
@@ -1,0 +1,28 @@
+-PART[nfs-panel-deploying-advanced-1x1-ikonos-1] {}
+-PART[nfs-panel-deploying-advanced-1x1-messenger-1] {}
+-PART[nfs-panel-deploying-advanced-1x2-mro-1] {}
+-PART[nfs-panel-deploying-advanced-1x2-wv4-1] {}
+-PART[nfs-panel-deploying-advanced-1x3-orion-1] {}
+-PART[nfs-panel-deploying-advanced-1x3-orion-2] {}
+-PART[nfs-panel-deploying-advanced-1x4-dragon-1] {}
+-PART[nfs-panel-deploying-advanced-1x4-dragon-2] {}
+-PART[nfs-panel-deploying-advanced-1x5-dawn-1] {}
+-PART[nfs-panel-deploying-advanced-1x5-goes-1] {}
+-PART[nfs-panel-deploying-advanced-2x6x6-lab-1] {}
+-PART[nfs-panel-deploying-advanced-2x20-hub-1] {}
+-PART[nfs-panel-deploying-advanced-3x1-hayabusa-1] {}
+-PART[nfs-panel-deploying-advanced-3x1-tdrss-1] {}
+-PART[nfs-panel-deploying-advanced-3x1-wv3-1] {}
+
+-PART[nfs-panel-deploying-blanket-arm-1] {}
+-PART[nfs-panel-deploying-blanket-bfs-1] {}
+-PART[nfs-panel-deploying-blanket-copernicus-1] {}
+-PART[nfs-panel-deploying-blanket-drm-1] {}
+-PART[nfs-panel-deploying-blanket-dsg-1] {}
+-PART[nfs-panel-deploying-blanket-dst-1] {}
+-PART[nfs-panel-deploying-blanket-nautilus-1] {}
+-PART[nfs-panel-deploying-blanket-orion-1] {}
+-PART[nfs-panel-deploying-blanket-starship-1] {}
+
+-PART[nfs-panel-deploying-concentrator-juice-1] {}
+-PART[nfs-panel-deploying-concentrator-juno-1] {}

--- a/GameData/ROSolar/ModIntegration/NearFutureSolar/ROS_PanelsRework.cfg
+++ b/GameData/ROSolar/ModIntegration/NearFutureSolar/ROS_PanelsRework.cfg
@@ -1,0 +1,63 @@
+@PART[ROS-FoldingSolarPanel]:NEEDS[NearFutureSolar]:AFTER[ROSolar]
+{
+	// Standard panels are added to the "folding" config under different cores, to keep categories small...
+	@MODULE[ModuleROSolar]
+	{
+		@CORE:HAS[#variant[Single]]
+		{
+			model = NFS_DeployingAdv_ikonos-1
+			model = NFS_DeployingAdv_messenger-1
+		}
+		
+		@CORE:HAS[#variant[1x2]]
+		{
+			model = NFS_DeployingAdv_mro-1
+			model = NFS_DeployingAdv_wv4-1
+		}
+		
+		@CORE:HAS[#variant[1x3]]
+		{
+			model = NFS_DeployingAdv_orion-1
+			model = NFS_DeployingAdv_orion-2
+		}
+		
+		@CORE:HAS[#variant[1x4]]
+		{
+			model = NFS_DeployingAdv_dragon-1
+			model = NFS_DeployingAdv_dragon-2
+			model = NFS_DeployingCon_juno-1
+		}
+		
+		CORE
+		{
+			variant = 1x5
+			model = NFS_DeployingAdv_goes-1
+		}
+		
+		CORE
+		{
+			variant = 2x6x6
+			model = NFS_DeployingAdv_lab-1
+		}
+		
+		CORE
+		{
+			variant = 2x20
+			model = NFS_DeployingAdv_hub-1
+		}
+		
+		CORE
+		{
+			variant = 3x1
+			model = NFS_DeployingAdv_hayabusa-1
+			model = NFS_DeployingAdv_tdrss-1
+			model = NFS_DeployingAdv_wv3-1
+		}
+		
+		CORE
+		{
+			variant = 1x3x1
+			model = NFS_DeployingCon_juice-1
+		}	
+	}
+}


### PR DESCRIPTION
This commit ports most of the NearFutureSolar models to the ROSolar parts, given that mod is found on GameData. 

- The models are either added to FoldingSolarPanel (under new or pre-existing `CORE` nodes) or to the new BlanketSolarPanel part. 
- Length, width, area and height were calculated for each panel. 
- The PR also includes a patch that removes the NFS parts whose models were ported.
- The BFS solar panel model might not have an entirely accurate area value.