### PR TITLE
Add Restock Gigantor cfg

### DIFF
--- a/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
+++ b/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
@@ -6,11 +6,11 @@ ROL_MODEL:NEEDS[ReStock]
 	name = ReStock_gigantor
 	title = ReStock Gigantor
 	modelName = ReStock/Assets/Electrical/restock-solarpanel-gigantor
-//	panelLength = 6
-//	panelWidth = 2.2
+	panelLength = 6
+	panelWidth = 2.2
 	panelArea = 11.4 // 1.9*6, there's a gap.
 	secondaryTransformName = suncatcher
-	pivotName = suncatcher // FIXME probably shouldn't be same as secondaryTransformName, but seems to work
+	// pivotName = nothing, use default
 	animationName = bigsolarpanel
 	surface = 0,0,0,1,0,0,1
 	isTracking = true

--- a/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
+++ b/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
@@ -13,6 +13,6 @@ ROL_MODEL:NEEDS[ReStock]
 	// pivotName = nothing, use default
 	animationName = bigsolarpanel
 	surface = 0,0,0,1,0,0,1
+	rotationOffset = -90, 0, 0
 	isTracking = true
 }
-

--- a/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
+++ b/GameData/ROSolar/Data/Models/ModelData-Restock.cfg
@@ -1,0 +1,18 @@
+// This file is for extra restock models that have NOT been imported into ROSolar. Will only be available if restock is installed
+
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = ReStock_gigantor
+	title = ReStock Gigantor
+	modelName = ReStock/Assets/Electrical/restock-solarpanel-gigantor
+//	panelLength = 6
+//	panelWidth = 2.2
+	panelArea = 11.4 // 1.9*6, there's a gap.
+	secondaryTransformName = suncatcher
+	pivotName = suncatcher // FIXME probably shouldn't be same as secondaryTransformName, but seems to work
+	animationName = bigsolarpanel
+	surface = 0,0,0,1,0,0,1
+	isTracking = true
+}
+

--- a/GameData/ROSolar/Parts/Restock_Parts.cfg
+++ b/GameData/ROSolar/Parts/Restock_Parts.cfg
@@ -1,0 +1,22 @@
+// This file for adding restock-specific models to 'standard' ROSolar parts
+@PART[ROS-FoldingSolarPanel]:NEEDS[ReStock]:BEFORE[ROSolar]
+{
+	@MODULE[ModuleROSolar]:HAS[@CORE:HAS[~variant[Other]]]
+	{
+		CORE
+		{
+			variant = Other
+		}
+	}
+}
+
+@PART[ROS-FoldingSolarPanel]:NEEDS[ReStock]:AFTER[ROSolar]
+{
+	@MODULE[ModuleROSolar]
+	{
+		@CORE:HAS[#variant[Other]]
+		{
+			model = ReStock_gigantor // TODO: move to a new part (Accordion?); this isn't really "folding" in the same sense as the rest
+		}
+	}
+}

--- a/GameData/ROSolar/Parts/Restock_Parts.cfg
+++ b/GameData/ROSolar/Parts/Restock_Parts.cfg
@@ -1,7 +1,7 @@
 // This file for adding restock-specific models to 'standard' ROSolar parts
 @PART[ROS-FoldingSolarPanel]:NEEDS[ReStock]:BEFORE[ROSolar]
 {
-	@MODULE[ModuleROSolar]:HAS[@CORE:HAS[~variant[Other]]]
+	@MODULE[ModuleROSolar]:HAS[!CORE:HAS[#variant[Other]]]
 	{
 		CORE
 		{


### PR DESCRIPTION
No model import, just use model from restock if installed. Based on
NFS configs.
Added to Folding panels, for lack of a better one

Per discord discussion, it may be better to create a new part for "station" panels; but that's a bigger job than I'm prepared for, so sharing what I have, might at least serve as starting point.

Probably shouldn't merge this if it's going to get removed later; that'd presumably be craft-breaking.