### PR TITLE
Make the DST and DSG solar array models cappable of sun tracking

### DIFF
--- a/GameData/ROSolar/Data/Models/ModelData-NFS.cfg
+++ b/GameData/ROSolar/Data/Models/ModelData-NFS.cfg
@@ -401,7 +401,7 @@ ROL_MODEL:NEEDS[NearFutureSolar]
 	animationName = PanelsExtend
 	pivotName = B_GatewayPanelPivot
 	surface = 0,0,0,1,0,0,1
-	isTracking = false
+	isTracking = true
 }
 
 ROL_MODEL:NEEDS[NearFutureSolar]
@@ -422,7 +422,7 @@ ROL_MODEL:NEEDS[NearFutureSolar]
 	animationName = PanelsExtend
 	pivotName = B_DSTPanelPivot
 	surface = 0,0,0,1,0,0,1
-	isTracking = false
+	isTracking = true
 }
 
 ROL_MODEL:NEEDS[NearFutureSolar]


### PR DESCRIPTION
Just a simple change in the Near Future Solar model config to allow them to sun track, I see no reason as to why they cant.